### PR TITLE
Update README.md to mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Build Status](https://travis-ci.com/alphagov/verify-idp-guidance.svg?branch=master)](https://travis-ci.com/alphagov/verify-idp-guidance)
 
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
+
 ## Getting started
 
 To preview or build the website, we need to use the terminal.


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.